### PR TITLE
Fixes #2

### DIFF
--- a/src/Traits/MediaFile.php
+++ b/src/Traits/MediaFile.php
@@ -30,7 +30,7 @@ trait MediaFile {
 
     private function isVideo($file)
     {
-        return $this->mediaHasAudio($file) && $this->mediaHasVideo($file);
+        return $this->mediaHasVideo($file);
     }
 
     private function mediaHasAudio($file) {

--- a/src/Traits/MediaFile.php
+++ b/src/Traits/MediaFile.php
@@ -13,6 +13,7 @@ trait MediaFile {
     private function createFFProbe() {
         $this->ffprobe = FFProbe::create([
             'ffprobe.binaries' => [
+                'C:/FFmpeg/bin/ffprobe.exe',
                 'ffprobe',
                 '/usr/bin/ffprobe',
                 '/usr/local/bin/ffprobe',


### PR DESCRIPTION
This change fixes the issue #2 which doesn't let you validate videos that don't have an audio stream, this way it only checks if it has a video stream ( which is the case for a large number of videos that only have a video stream without any audio, ex : shutterstock videos and most stock videos ) 