### PR TITLE
Add livewire support by adding `getRealPath` method control

### DIFF
--- a/src/Traits/MediaFile.php
+++ b/src/Traits/MediaFile.php
@@ -25,11 +25,19 @@ trait MediaFile {
 
     private function isAudio($file)
     {
+        if (method_exists($file, 'getRealPath')) {
+            $file = $file->getRealPath();
+        }
+
         return $this->mediaHasAudio($file) && !$this->mediaHasVideo($file);
     }
 
     private function isVideo($file)
     {
+        if (method_exists($file, 'getRealPath')) {
+            $file = $file->getRealPath();
+        }
+
         return $this->mediaHasAudio($file) && $this->mediaHasVideo($file);
     }
 

--- a/src/Traits/MediaFile.php
+++ b/src/Traits/MediaFile.php
@@ -25,7 +25,9 @@ trait MediaFile {
 
     private function isAudio($file)
     {
-        if (method_exists($file, 'getRealPath')) {
+        if (method_exists($file, 'getS3StreamAccessiblePath')) {
+            $file = $file->getS3StreamAccessiblePath();
+        } elseif (method_exists($file, 'getRealPath')) {
             $file = $file->getRealPath();
         }
 
@@ -34,7 +36,9 @@ trait MediaFile {
 
     private function isVideo($file)
     {
-        if (method_exists($file, 'getRealPath')) {
+        if (method_exists($file, 'getS3StreamAccessiblePath')) {
+            $file = $file->getS3StreamAccessiblePath();
+        } elseif (method_exists($file, 'getRealPath')) {
             $file = $file->getRealPath();
         }
 

--- a/src/Traits/MediaFile.php
+++ b/src/Traits/MediaFile.php
@@ -25,7 +25,7 @@ trait MediaFile {
 
     private function isAudio($file)
     {
-        if (method_exists($file, 'getS3StreamAccessiblePath')) {
+        if (method_exists($file, 'hasMacro') && $file::hasMacro('getS3StreamAccessiblePath')) {
             $file = $file->getS3StreamAccessiblePath();
         } elseif (method_exists($file, 'getRealPath')) {
             $file = $file->getRealPath();
@@ -36,7 +36,7 @@ trait MediaFile {
 
     private function isVideo($file)
     {
-        if (method_exists($file, 'getS3StreamAccessiblePath')) {
+        if (method_exists($file, 'hasMacro') && $file::hasMacro('getS3StreamAccessiblePath')) {
             $file = $file->getS3StreamAccessiblePath();
         } elseif (method_exists($file, 'getRealPath')) {
             $file = $file->getRealPath();


### PR DESCRIPTION
Currently it does not work for Livewire\Features\SupportFileUploads\TemporaryUploadedFile, this PR makes it work with Livewire TemporaryUploadedFiles.